### PR TITLE
Allow DRF PictureField to accept aspect_ratios

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Responsive cross-browser image library using modern codes like AVIF & WebP.
 * serve files with or without a CDN
 * placeholders for local development
 * migration support
-* async image processing for Celery or Dramatiq
+* async image processing for [Celery] or [Dramatiq]
+* [DRF] support
 
 [![PyPi Version](https://img.shields.io/pypi/v/django-pictures.svg)](https://pypi.python.org/pypi/django-pictures/)
 [![Test Coverage](https://codecov.io/gh/codingjoe/django-pictures/branch/main/graph/badge.svg)](https://codecov.io/gh/codingjoe/django-pictures)
@@ -194,7 +195,7 @@ You can follow [the example][migration] in our test app, to see how it works.
 
 ## Contrib
 
-### Django Rest Framework (DRF)
+### Django Rest Framework ([DRF])
 
 We do ship with a read-only `PictureField` that can be used to include all
 available picture sizes in a DRF serializer.
@@ -244,3 +245,7 @@ Note that the `media` keys are only included, if you have specified breakpoints.
 
 `PictureField` is compatible with [Django Cleanup](https://github.com/un1t/django-cleanup),
 which automatically deletes its file and corresponding `SimplePicture` files.
+
+[drf]: https://www.django-rest-framework.org/
+[celery]: https://docs.celeryproject.org/en/stable/
+[dramatiq]: https://dramatiq.io/

--- a/README.md
+++ b/README.md
@@ -220,21 +220,15 @@ curl http://localhost:8000/api/path/?picture_ratio=16%2F9&picture_m=6&picture_l=
 {
   "other_fields": "…",
   "picture": {
-    "url": "/media/testapp/profile/image.jpg",
+    "url": "/path/to/image.jpg",
     "width": 800,
     "height": 800,
     "ratios": {
       "1/1": {
         "sources": {
           "image/webp": {
-            "800": "/media/testapp/profile/image/1/800w.webp",
-            "100": "/media/testapp/profile/image/1/100w.webp",
-            "200": "/media/testapp/profile/image/1/200w.webp",
-            "300": "/media/testapp/profile/image/1/300w.webp",
-            "400": "/media/testapp/profile/image/1/400w.webp",
-            "500": "/media/testapp/profile/image/1/500w.webp",
-            "600": "/media/testapp/profile/image/1/600w.webp",
-            "700": "/media/testapp/profile/image/1/700w.webp"
+            "100": "/path/to/image/1/100w.webp",
+            "200": "…"
           }
         },
         "media": "(min-width: 0px) and (max-width: 991px) 100vw, (min-width: 992px) and (max-width: 1199px) 33vw, 25vw"

--- a/README.md
+++ b/README.md
@@ -207,6 +207,45 @@ class PictureSerializer(serializers.Serializer):
     picture = PictureField()
 ```
 
+You may provide optional GET parameters to the serializer, to specify the aspect
+ratio and breakpoints you want to include in the response. The parameters are
+prefixed with the `fieldname_` to avoid conflicts with other fields.
+
+```bash
+curl http://localhost:8000/api/path/?picture_ratio=16%2F9&picture_m=6&picture_l=4
+# %2F is the url encoded slash
+```
+
+```json
+{
+  "other_fields": "…",
+  "picture": {
+    "url": "/media/testapp/profile/image.jpg",
+    "width": 800,
+    "height": 800,
+    "ratios": {
+      "1/1": {
+        "sources": {
+          "image/webp": {
+            "800": "/media/testapp/profile/image/1/800w.webp",
+            "100": "/media/testapp/profile/image/1/100w.webp",
+            "200": "/media/testapp/profile/image/1/200w.webp",
+            "300": "/media/testapp/profile/image/1/300w.webp",
+            "400": "/media/testapp/profile/image/1/400w.webp",
+            "500": "/media/testapp/profile/image/1/500w.webp",
+            "600": "/media/testapp/profile/image/1/600w.webp",
+            "700": "/media/testapp/profile/image/1/700w.webp"
+          }
+        },
+        "media": "(min-width: 0px) and (max-width: 991px) 100vw, (min-width: 992px) and (max-width: 1199px) 33vw, 25vw"
+      }
+    }
+  }
+}
+```
+
+Note that the `media` keys are only included, if you have specified breakpoints.
+
 ### Django Cleanup
 
 `PictureField` is compatible with [Django Cleanup](https://github.com/un1t/django-cleanup),

--- a/pictures/contrib/rest_framework.py
+++ b/pictures/contrib/rest_framework.py
@@ -16,5 +16,22 @@ def default(obj):
 class PictureField(serializers.ReadOnlyField):
     """Read-only field for all aspect ratios and sizes of the image."""
 
+    def __init__(self, **kwargs):
+        self.aspect_ratios = kwargs.pop("aspect_ratios", None)
+        super().__init__(**kwargs)
+
     def to_representation(self, obj: PictureFieldFile):
-        return json.loads(json.dumps(obj.aspect_ratios, default=default))
+        if self.aspect_ratios is None:
+            return json.loads(json.dumps(obj.aspect_ratios, default=default))
+
+        for ratio in self.aspect_ratios:
+            if ratio not in obj.aspect_ratios:
+                raise ValueError(
+                    f"Invalid ratio: {ratio}. Choices are: {', '.join(filter(None, obj.aspect_ratios.keys()))}"
+                )
+        return json.loads(
+            json.dumps(
+                {ratio: obj.aspect_ratios[ratio] for ratio in self.aspect_ratios},
+                default=default,
+            )
+        )

--- a/pictures/contrib/rest_framework.py
+++ b/pictures/contrib/rest_framework.py
@@ -4,6 +4,8 @@ from rest_framework import serializers
 
 __all__ = ["PictureField"]
 
+from pictures import utils
+from pictures.conf import get_settings
 from pictures.models import PictureFieldFile, SimplePicture
 
 
@@ -16,22 +18,33 @@ def default(obj):
 class PictureField(serializers.ReadOnlyField):
     """Read-only field for all aspect ratios and sizes of the image."""
 
-    def __init__(self, **kwargs):
-        self.aspect_ratios = kwargs.pop("aspect_ratios", None)
+    def __init__(self, ratio=None, container=None, **kwargs):
+        self.ratio = ratio
+        self.container = container
+        self.breakpoints = {
+            bp: kwargs.pop(bp) for bp in get_settings().BREAKPOINTS if bp in kwargs
+        }
         super().__init__(**kwargs)
 
     def to_representation(self, obj: PictureFieldFile):
-        if self.aspect_ratios is None:
+        if self.ratio is None:
             return json.loads(json.dumps(obj.aspect_ratios, default=default))
 
-        for ratio in self.aspect_ratios:
-            if ratio not in obj.aspect_ratios:
-                raise ValueError(
-                    f"Invalid ratio: {ratio}. Choices are: {', '.join(filter(None, obj.aspect_ratios.keys()))}"
-                )
+        try:
+            sources = obj.aspect_ratios[self.ratio]
+        except KeyError as e:
+            raise ValueError(
+                f"Invalid ratio: {self.ratio}. Choices are: {', '.join(filter(None, obj.aspect_ratios.keys()))}"
+            ) from e
+
         return json.loads(
             json.dumps(
-                {ratio: obj.aspect_ratios[ratio] for ratio in self.aspect_ratios},
+                {
+                    "sources": sources,
+                    "media": utils.sizes(
+                        container_width=self.container, **self.breakpoints
+                    ),
+                },
                 default=default,
             )
         )

--- a/pictures/contrib/rest_framework.py
+++ b/pictures/contrib/rest_framework.py
@@ -38,12 +38,12 @@ class PictureField(serializers.ReadOnlyField):
         except KeyError:
             pass
         else:
-            ratio = query_params.get("ratio")
-            container = query_params.get("container")
+            ratio = query_params.get(f"{self.source}_ratio")
+            container = query_params.get(f"{self.source}_container")
             breakpoints = {
-                bp: int(query_params.get(bp))
+                bp: int(query_params.get(f"{self.source}_{bp}"))
                 for bp in get_settings().BREAKPOINTS
-                if bp in query_params
+                if f"{self.source}_{bp}" in query_params
             }
             if ratio is not None:
                 try:

--- a/tests/contrib/test_rest_framework.py
+++ b/tests/contrib/test_rest_framework.py
@@ -47,78 +47,104 @@ class TestPictureField:
 
         profile = models.Profile.objects.create(picture=image_upload_file)
         serializer = ProfileSerializer(profile)
+
         assert serializer.data["picture"] == {
-            "null": {
-                "WEBP": {
-                    "800": "/media/testapp/profile/image/800w.webp",
-                    "100": "/media/testapp/profile/image/100w.webp",
-                    "200": "/media/testapp/profile/image/200w.webp",
-                    "300": "/media/testapp/profile/image/300w.webp",
-                    "400": "/media/testapp/profile/image/400w.webp",
-                    "500": "/media/testapp/profile/image/500w.webp",
-                    "600": "/media/testapp/profile/image/600w.webp",
-                    "700": "/media/testapp/profile/image/700w.webp",
-                }
-            },
-            "1/1": {
-                "WEBP": {
-                    "800": "/media/testapp/profile/image/1/800w.webp",
-                    "100": "/media/testapp/profile/image/1/100w.webp",
-                    "200": "/media/testapp/profile/image/1/200w.webp",
-                    "300": "/media/testapp/profile/image/1/300w.webp",
-                    "400": "/media/testapp/profile/image/1/400w.webp",
-                    "500": "/media/testapp/profile/image/1/500w.webp",
-                    "600": "/media/testapp/profile/image/1/600w.webp",
-                    "700": "/media/testapp/profile/image/1/700w.webp",
-                }
-            },
-            "3/2": {
-                "WEBP": {
-                    "800": "/media/testapp/profile/image/3_2/800w.webp",
-                    "100": "/media/testapp/profile/image/3_2/100w.webp",
-                    "200": "/media/testapp/profile/image/3_2/200w.webp",
-                    "300": "/media/testapp/profile/image/3_2/300w.webp",
-                    "400": "/media/testapp/profile/image/3_2/400w.webp",
-                    "500": "/media/testapp/profile/image/3_2/500w.webp",
-                    "600": "/media/testapp/profile/image/3_2/600w.webp",
-                    "700": "/media/testapp/profile/image/3_2/700w.webp",
-                }
-            },
-            "16/9": {
-                "WEBP": {
-                    "800": "/media/testapp/profile/image/16_9/800w.webp",
-                    "100": "/media/testapp/profile/image/16_9/100w.webp",
-                    "200": "/media/testapp/profile/image/16_9/200w.webp",
-                    "300": "/media/testapp/profile/image/16_9/300w.webp",
-                    "400": "/media/testapp/profile/image/16_9/400w.webp",
-                    "500": "/media/testapp/profile/image/16_9/500w.webp",
-                    "600": "/media/testapp/profile/image/16_9/600w.webp",
-                    "700": "/media/testapp/profile/image/16_9/700w.webp",
-                }
+            "url": "/media/testapp/profile/image.jpg",
+            "width": 800,
+            "height": 800,
+            "ratios": {
+                "null": {
+                    "sources": {
+                        "image/webp": {
+                            "800": "/media/testapp/profile/image/800w.webp",
+                            "100": "/media/testapp/profile/image/100w.webp",
+                            "200": "/media/testapp/profile/image/200w.webp",
+                            "300": "/media/testapp/profile/image/300w.webp",
+                            "400": "/media/testapp/profile/image/400w.webp",
+                            "500": "/media/testapp/profile/image/500w.webp",
+                            "600": "/media/testapp/profile/image/600w.webp",
+                            "700": "/media/testapp/profile/image/700w.webp",
+                        }
+                    }
+                },
+                "1/1": {
+                    "sources": {
+                        "image/webp": {
+                            "800": "/media/testapp/profile/image/1/800w.webp",
+                            "100": "/media/testapp/profile/image/1/100w.webp",
+                            "200": "/media/testapp/profile/image/1/200w.webp",
+                            "300": "/media/testapp/profile/image/1/300w.webp",
+                            "400": "/media/testapp/profile/image/1/400w.webp",
+                            "500": "/media/testapp/profile/image/1/500w.webp",
+                            "600": "/media/testapp/profile/image/1/600w.webp",
+                            "700": "/media/testapp/profile/image/1/700w.webp",
+                        }
+                    }
+                },
+                "3/2": {
+                    "sources": {
+                        "image/webp": {
+                            "800": "/media/testapp/profile/image/3_2/800w.webp",
+                            "100": "/media/testapp/profile/image/3_2/100w.webp",
+                            "200": "/media/testapp/profile/image/3_2/200w.webp",
+                            "300": "/media/testapp/profile/image/3_2/300w.webp",
+                            "400": "/media/testapp/profile/image/3_2/400w.webp",
+                            "500": "/media/testapp/profile/image/3_2/500w.webp",
+                            "600": "/media/testapp/profile/image/3_2/600w.webp",
+                            "700": "/media/testapp/profile/image/3_2/700w.webp",
+                        }
+                    }
+                },
+                "16/9": {
+                    "sources": {
+                        "image/webp": {
+                            "800": "/media/testapp/profile/image/16_9/800w.webp",
+                            "100": "/media/testapp/profile/image/16_9/100w.webp",
+                            "200": "/media/testapp/profile/image/16_9/200w.webp",
+                            "300": "/media/testapp/profile/image/16_9/300w.webp",
+                            "400": "/media/testapp/profile/image/16_9/400w.webp",
+                            "500": "/media/testapp/profile/image/16_9/500w.webp",
+                            "600": "/media/testapp/profile/image/16_9/600w.webp",
+                            "700": "/media/testapp/profile/image/16_9/700w.webp",
+                        }
+                    }
+                },
             },
         }
 
     @pytest.mark.django_db
-    def test_to_representation__with_aspect_ratios(self, image_upload_file, settings):
+    def test_to_representation__with_aspect_ratios(
+        self, rf, image_upload_file, settings
+    ):
         settings.PICTURES["USE_PLACEHOLDERS"] = False
 
         profile = models.Profile.objects.create(picture=image_upload_file)
-        serializer = ProfileSerializer(profile)
-        serializer.fields["picture"].ratio = "16/9"
-        serializer.fields["picture"].breakpoints = {"m": 4, "l": 3}
+        request = rf.get("/")
+        request.GET._mutable = True
+        request.GET["ratio"] = "1/1"
+        request.GET["l"] = "3"
+        request.GET["m"] = "4"
+        serializer = ProfileSerializer(profile, context={"request": request})
 
         assert serializer.data["picture"] == {
-            "sources": {
-                "WEBP": {
-                    "800": "/media/testapp/profile/image/16_9/800w.webp",
-                    "100": "/media/testapp/profile/image/16_9/100w.webp",
-                    "200": "/media/testapp/profile/image/16_9/200w.webp",
-                    "300": "/media/testapp/profile/image/16_9/300w.webp",
-                    "400": "/media/testapp/profile/image/16_9/400w.webp",
-                    "500": "/media/testapp/profile/image/16_9/500w.webp",
-                    "600": "/media/testapp/profile/image/16_9/600w.webp",
-                    "700": "/media/testapp/profile/image/16_9/700w.webp",
+            "url": "/media/testapp/profile/image.jpg",
+            "width": 800,
+            "height": 800,
+            "ratios": {
+                "1/1": {
+                    "sources": {
+                        "image/webp": {
+                            "800": "/media/testapp/profile/image/1/800w.webp",
+                            "100": "/media/testapp/profile/image/1/100w.webp",
+                            "200": "/media/testapp/profile/image/1/200w.webp",
+                            "300": "/media/testapp/profile/image/1/300w.webp",
+                            "400": "/media/testapp/profile/image/1/400w.webp",
+                            "500": "/media/testapp/profile/image/1/500w.webp",
+                            "600": "/media/testapp/profile/image/1/600w.webp",
+                            "700": "/media/testapp/profile/image/1/700w.webp",
+                        }
+                    },
+                    "media": "(min-width: 0px) and (max-width: 991px) 100vw, (min-width: 992px) and (max-width: 1199px) 33vw, 25vw",
                 }
             },
-            "media": "(min-width: 0px) and (max-width: 991px) 100vw, (min-width: 992px) and (max-width: 1199px) 33vw, 25vw",
         }

--- a/tests/contrib/test_rest_framework.py
+++ b/tests/contrib/test_rest_framework.py
@@ -104,22 +104,11 @@ class TestPictureField:
 
         profile = models.Profile.objects.create(picture=image_upload_file)
         serializer = ProfileSerializer(profile)
-        serializer.fields["picture"].aspect_ratios = ["1/1", "16/9"]
+        serializer.fields["picture"].ratio = "16/9"
+        serializer.fields["picture"].breakpoints = {"m": 4, "l": 3}
 
         assert serializer.data["picture"] == {
-            "1/1": {
-                "WEBP": {
-                    "800": "/media/testapp/profile/image/1/800w.webp",
-                    "100": "/media/testapp/profile/image/1/100w.webp",
-                    "200": "/media/testapp/profile/image/1/200w.webp",
-                    "300": "/media/testapp/profile/image/1/300w.webp",
-                    "400": "/media/testapp/profile/image/1/400w.webp",
-                    "500": "/media/testapp/profile/image/1/500w.webp",
-                    "600": "/media/testapp/profile/image/1/600w.webp",
-                    "700": "/media/testapp/profile/image/1/700w.webp",
-                }
-            },
-            "16/9": {
+            "sources": {
                 "WEBP": {
                     "800": "/media/testapp/profile/image/16_9/800w.webp",
                     "100": "/media/testapp/profile/image/16_9/100w.webp",
@@ -131,4 +120,5 @@ class TestPictureField:
                     "700": "/media/testapp/profile/image/16_9/700w.webp",
                 }
             },
+            "media": "(min-width: 0px) and (max-width: 991px) 100vw, (min-width: 992px) and (max-width: 1199px) 33vw, 25vw",
         }

--- a/tests/contrib/test_rest_framework.py
+++ b/tests/contrib/test_rest_framework.py
@@ -121,9 +121,9 @@ class TestPictureField:
         profile = models.Profile.objects.create(picture=image_upload_file)
         request = rf.get("/")
         request.GET._mutable = True
-        request.GET["ratio"] = "1/1"
-        request.GET["l"] = "3"
-        request.GET["m"] = "4"
+        request.GET["picture_ratio"] = "1/1"
+        request.GET["picture_l"] = "3"
+        request.GET["picture_m"] = "4"
         serializer = ProfileSerializer(profile, context={"request": request})
 
         assert serializer.data["picture"] == {

--- a/tests/contrib/test_rest_framework.py
+++ b/tests/contrib/test_rest_framework.py
@@ -97,3 +97,38 @@ class TestPictureField:
                 }
             },
         }
+
+    @pytest.mark.django_db
+    def test_to_representation__with_aspect_ratios(self, image_upload_file, settings):
+        settings.PICTURES["USE_PLACEHOLDERS"] = False
+
+        profile = models.Profile.objects.create(picture=image_upload_file)
+        serializer = ProfileSerializer(profile)
+        serializer.fields["picture"].aspect_ratios = ["1/1", "16/9"]
+
+        assert serializer.data["picture"] == {
+            "1/1": {
+                "WEBP": {
+                    "800": "/media/testapp/profile/image/1/800w.webp",
+                    "100": "/media/testapp/profile/image/1/100w.webp",
+                    "200": "/media/testapp/profile/image/1/200w.webp",
+                    "300": "/media/testapp/profile/image/1/300w.webp",
+                    "400": "/media/testapp/profile/image/1/400w.webp",
+                    "500": "/media/testapp/profile/image/1/500w.webp",
+                    "600": "/media/testapp/profile/image/1/600w.webp",
+                    "700": "/media/testapp/profile/image/1/700w.webp",
+                }
+            },
+            "16/9": {
+                "WEBP": {
+                    "800": "/media/testapp/profile/image/16_9/800w.webp",
+                    "100": "/media/testapp/profile/image/16_9/100w.webp",
+                    "200": "/media/testapp/profile/image/16_9/200w.webp",
+                    "300": "/media/testapp/profile/image/16_9/300w.webp",
+                    "400": "/media/testapp/profile/image/16_9/400w.webp",
+                    "500": "/media/testapp/profile/image/16_9/500w.webp",
+                    "600": "/media/testapp/profile/image/16_9/600w.webp",
+                    "700": "/media/testapp/profile/image/16_9/700w.webp",
+                }
+            },
+        }


### PR DESCRIPTION
You may provide optional GET parameters to the serializer, to specify the aspect
ratio and breakpoints you want to include in the response. The parameters are
prefixed with the `fieldname_` to avoid conflicts with other fields.

```bash
curl http://localhost:8000/api/path/?picture_ratio=16%2F9&picture_m=6&picture_l=4
# %2F is the url encoded slash
```

```json
{
  "other_fields": "…",
  "picture": {
    "url": "/path/to/image.jpg",
    "width": 800,
    "height": 800,
    "ratios": {
      "1/1": {
        "sources": {
          "image/webp": {
            "100": "/path/to/image/1/100w.webp",
            "200": "…"
          }
        },
        "media": "(min-width: 0px) and (max-width: 991px) 100vw, (min-width: 992px) and (max-width: 1199px) 33vw, 25vw"
      }
    }
  }
}
```

Note that the `media` keys are only included, if you have specified breakpoints.