### PR TITLE
Document img_url template tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,15 +107,24 @@ if get_settings().USE_PLACEHOLDERS:
     ]
 ```
 
-### Legacy use-cases
+### Legacy use-cases (email)
 
-The template tag `img_url` can be used when a single image with a certain width
-is required (for example in emails) instead of a set of images.
+Although the `picture`-tag is [adequate for most use-cases][caniuse-picture],
+some remain, where a single `img` tag is necessary. Notably in email, where
+[most clients do support WebP][caniemail-webp] but not [srcset][caniemail-srcset].
+The template tag `img_url` returns a single size image URL.
+In addition to the ratio you will need to define the `file_type`
+as well as the `width` (absolute width in pixels).
+
 
 ```html
 {% load pictures %}
-{% img_url profile.picture ratio="3/2" file_type="webp" width=800 %}
+<img src="{% img_url profile.picture ratio="3/2" file_type="webp" width=800 %}" alt="profile picture">
 ```
+
+[caniuse-picture]: https://caniuse.com/picture
+[caniemail-webp]: https://www.caniemail.com/features/image-webp/
+[caniemail-srcset]: https://www.caniemail.com/features/html-srcset/
 
 ## Config
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ if get_settings().USE_PLACEHOLDERS:
     ]
 ```
 
+### Legacy use-cases
+
+The template tag `img_url` can be used when a single image with a certain width
+is required (for example in emails) instead of a set of images.
+
+```html
+{% load pictures %}
+{% img_url profile.picture ratio="3/2" file_type="webp" width=800 %}
+```
+
 ## Config
 
 ### Aspect ratios

--- a/pictures/templatetags/pictures.py
+++ b/pictures/templatetags/pictures.py
@@ -59,6 +59,6 @@ def img_url(field_file, file_type, width, ratio=None) -> str:
         ) from e
     for w, img in sorted(sizes.items()):
         url = img.url
-        if w >= width:
+        if w >= int(width):
             break
     return url

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -67,7 +67,7 @@ def test_picture__additional_attrs(image_upload_file):
 def test_img_url(image_upload_file):
     profile = Profile.objects.create(name="Spiderman", picture=image_upload_file)
     assert (
-        img_url(profile.picture, ratio="3/2", file_type="webp", width=800)
+        img_url(profile.picture, ratio="3/2", file_type="webp", width="800")
         == "/_pictures/image/3x2/800w.WEBP"
     )
 


### PR DESCRIPTION
Right when I needed the something like the `img_url` tag in my project, you had already added it. Thank you very much for this! 🙏🏻 

It would be nice for new users to find out about it as soon as they are skimming the README.