### PR TITLE
fixing f-string in image model warning

### DIFF
--- a/pictures/models.py
+++ b/pictures/models.py
@@ -234,7 +234,7 @@ class PictureField(ImageField):
                     "width_field and height_field attributes are missing",
                     obj=self,
                     id="fields.E101",
-                    hint="Please add two positive integer fields to '{self.model._meta.app_label}.{self.model.__name__}' and add their field names as the 'width_field' and 'height_field' attribute for your picture field. Otherwise Django will not be able to cache the image aspect size causing disk IO and potential response time increases.",
+                    hint=f"Please add two positive integer fields to '{self.model._meta.app_label}.{self.model.__name__}' and add their field names as the 'width_field' and 'height_field' attribute for your picture field. Otherwise Django will not be able to cache the image aspect size causing disk IO and potential response time increases.",
                 )
             ]
         return []

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -374,9 +374,14 @@ class TestPictureField:
 
     def test_check_width_height_field(self):
         assert not PictureField(aspect_ratios=["3/2"])._check_width_height_field()
-        errors = PictureField(aspect_ratios=[None])._check_width_height_field()
+        field = PictureField(aspect_ratios=[None])
+        field.contribute_to_class(Profile, "picture")
+        errors = field._check_width_height_field()
         assert errors
         assert errors[0].id == "fields.E101"
+        assert errors[0].hint.startswith(
+            "Please add two positive integer fields to 'testapp.Profile'"
+        )
 
     def test_check(self):
         assert not SimpleModel._meta.get_field("picture").check()


### PR DESCRIPTION
Just the single `f` was missing for the formatted warning to be displayed correctly.
Thanks for that hint, by the way ;)