### PR TITLE
Fix #90 -- Container is smaller then smallest breakpoint

### DIFF
--- a/pictures/utils.py
+++ b/pictures/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 import random
 import sys
+import warnings
 from fractions import Fraction
 from functools import lru_cache
 from urllib.parse import unquote
@@ -39,7 +40,13 @@ def _media_query(*, container_width: int = None, **breakpoints: {str: int}):
             yield f"(min-width: {prev_width}px) and (max-width: {width - 1}px) {math.floor(prev_ratio * 100)}vw"
             prev_width = width
         prev_ratio = ratio
-    yield f"{math.floor(prev_ratio * container_width)}px" if container_width else f"{math.floor(prev_ratio * 100)}vw"
+    if prev_ratio:
+        yield f"{math.floor(prev_ratio * container_width)}px" if container_width else f"{math.floor(prev_ratio * 100)}vw"
+    else:
+        warnings.warn(
+            "Your container is smaller than all your breakpoints.", UserWarning
+        )
+        yield f"{container_width}px" if container_width else "100vw"
 
 
 def sizes(*, cols=12, container_width: int = None, **breakpoints: {str: int}) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -82,6 +82,16 @@ class TestSizes:
             " 600px"
         )
 
+    def test_container__smaller_than_breakpoint(self):
+        with pytest.warns() as records:
+            assert (
+                utils.sizes(container_width=500)
+                == "(min-width: 0px) and (max-width: 499px) 100vw, 500px"
+            )
+        assert str(records[0].message) == (
+            "Your container is smaller than all your breakpoints."
+        )
+
 
 class TestSourceSet:
     def test_default(self):


### PR DESCRIPTION
An error occured, if the container was smaller then all breakpoints.
This should not happen during regular usage, and will trigger a
user warning now. However, since the API allows any container
size to be passed, this can be use the cause an internal server
error and should be handled gracefully.

Co-authored-by: truongvan <truongvan@users.noreply.github.com>
