### PR TITLE
Fix #89 -- Handle invalid container values in DRF

### DIFF
--- a/pictures/contrib/rest_framework.py
+++ b/pictures/contrib/rest_framework.py
@@ -1,5 +1,6 @@
 import json
 
+from django.http import QueryDict
 from rest_framework import serializers
 
 __all__ = ["PictureField"]
@@ -34,12 +35,18 @@ class PictureField(serializers.ReadOnlyField):
             },
         }
         try:
-            query_params = self.context["request"].GET
+            query_params: QueryDict = self.context["request"].GET
         except KeyError:
             pass
         else:
             ratio = query_params.get(f"{self.source}_ratio")
             container = query_params.get(f"{self.source}_container")
+            try:
+                container = int(container)
+            except TypeError:
+                container = None
+            except ValueError as e:
+                raise ValueError(f"Container width is not a number: {container}") from e
             breakpoints = {
                 bp: int(query_params.get(f"{self.source}_{bp}"))
                 for bp in get_settings().BREAKPOINTS

--- a/tests/contrib/test_rest_framework.py
+++ b/tests/contrib/test_rest_framework.py
@@ -167,3 +167,86 @@ class TestPictureField:
             serializer.data["picture"]
 
         assert str(e.value) == "Invalid ratio: 21/11. Choices are: 1/1, 3/2, 16/9"
+
+    @pytest.mark.django_db
+    def test_to_representation__with_container(self, rf, image_upload_file, settings):
+        settings.PICTURES["USE_PLACEHOLDERS"] = False
+
+        profile = models.Profile.objects.create(picture=image_upload_file)
+        request = rf.get("/")
+        request.GET._mutable = True
+        request.GET["picture_ratio"] = "16/9"
+        request.GET["picture_container"] = "1200"
+        serializer = ProfileSerializer(profile, context={"request": request})
+        assert serializer.data["picture"] == {
+            "url": "/media/testapp/profile/image.jpg",
+            "width": 800,
+            "height": 800,
+            "ratios": {
+                "16/9": {
+                    "sources": {
+                        "image/webp": {
+                            "800": "/media/testapp/profile/image/16_9/800w.webp",
+                            "100": "/media/testapp/profile/image/16_9/100w.webp",
+                            "200": "/media/testapp/profile/image/16_9/200w.webp",
+                            "300": "/media/testapp/profile/image/16_9/300w.webp",
+                            "400": "/media/testapp/profile/image/16_9/400w.webp",
+                            "500": "/media/testapp/profile/image/16_9/500w.webp",
+                            "600": "/media/testapp/profile/image/16_9/600w.webp",
+                            "700": "/media/testapp/profile/image/16_9/700w.webp",
+                        }
+                    },
+                    "media": "(min-width: 0px) and (max-width: 1199px) 100vw, 1200px",
+                }
+            },
+        }
+
+    @pytest.mark.django_db
+    def test_to_representation__without_container(
+        self, rf, image_upload_file, settings
+    ):
+        settings.PICTURES["USE_PLACEHOLDERS"] = False
+
+        profile = models.Profile.objects.create(picture=image_upload_file)
+        request = rf.get("/")
+        request.GET._mutable = True
+        request.GET["picture_ratio"] = "16/9"
+        serializer = ProfileSerializer(profile, context={"request": request})
+        assert serializer.data["picture"] == {
+            "url": "/media/testapp/profile/image.jpg",
+            "width": 800,
+            "height": 800,
+            "ratios": {
+                "16/9": {
+                    "sources": {
+                        "image/webp": {
+                            "800": "/media/testapp/profile/image/16_9/800w.webp",
+                            "100": "/media/testapp/profile/image/16_9/100w.webp",
+                            "200": "/media/testapp/profile/image/16_9/200w.webp",
+                            "300": "/media/testapp/profile/image/16_9/300w.webp",
+                            "400": "/media/testapp/profile/image/16_9/400w.webp",
+                            "500": "/media/testapp/profile/image/16_9/500w.webp",
+                            "600": "/media/testapp/profile/image/16_9/600w.webp",
+                            "700": "/media/testapp/profile/image/16_9/700w.webp",
+                        }
+                    },
+                    "media": "100vw",
+                }
+            },
+        }
+
+    @pytest.mark.django_db
+    def test_to_representation__with_false_str_container(
+        self, rf, image_upload_file, settings
+    ):
+        settings.PICTURES["USE_PLACEHOLDERS"] = False
+
+        profile = models.Profile.objects.create(picture=image_upload_file)
+        request = rf.get("/")
+        request.GET._mutable = True
+        request.GET["picture_ratio"] = "16/9"
+        request.GET["picture_container"] = "not_a_number"
+        serializer = ProfileSerializer(profile, context={"request": request})
+        with pytest.raises(ValueError) as e:
+            serializer.data["picture"]
+        assert str(e.value) == "Container width is not a number: not_a_number"


### PR DESCRIPTION
A user may pass any container value to the endpoint, and we need
to ensure proper error handling and error messages.

Co-authored-by: truongvan <truongvan@users.noreply.github.com>
