### PR TITLE
Fix #106 -- discard alpha channel on PNGs

### DIFF
--- a/pictures/models.py
+++ b/pictures/models.py
@@ -74,6 +74,14 @@ class SimplePicture:
             image = ImageOps.fit(image, size)
         else:
             image.thumbnail(size)
+
+        self.discard_alpha(image)
+
+        return image
+
+    def discard_alpha(self, image):
+        if image.mode == "RGBA":
+            image = image.convert("RGB")
         return image
 
     def save(self, image):


### PR DESCRIPTION
@codingjoe this is a very simple draft made to start a discussion and see your opinion on how things should be handled here. Questions to consider:

- do we want to discard alpha channel or allow users to select a handling strategy?
- should we log this situation as a warning?
- shall we consider other modes, like "P" or "LA"?