### PR TITLE
Enable swapping the image processor via a setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ PICTURES = {
     "CONTAINER_WIDTH": 1200,
     "FILE_TYPES": ["WEBP"],
     "PIXEL_DENSITIES": [1, 2],
-    "USE_PLACEHOLDERS": True
+    "USE_PLACEHOLDERS": True,
+    "QUEUE_NAME": "pictures",
+    "PROCESSOR": "pictures.tasks.process_picture",
+
 }
 ```
 
@@ -206,6 +209,11 @@ densities.
 If you have either Dramatiq or Celery installed, we will default to async
 image processing. You will need workers to listen to the `pictures` queue.
 You can override the queue name, via the `PICTURES["QUEUE_NAME"]` setting.
+
+You can also override the processor, via the `PICTURES["PROCESSOR"]` setting.
+The default processor is `pictures.tasks.process_picture`. It takes a single
+argument, the `PictureFileFile` instance. You can use this to override the
+processor, should you need to do some custom processing.
 
 ## Migrations
 

--- a/pictures/conf.py
+++ b/pictures/conf.py
@@ -21,6 +21,7 @@ def get_settings():
             "PIXEL_DENSITIES": [1, 2],
             "USE_PLACEHOLDERS": settings.DEBUG,
             "QUEUE_NAME": "pictures",
+            "PROCESSOR": "pictures.tasks.process_picture",
             **getattr(settings, "PICTURES", {}),
         },
     )

--- a/pictures/models.py
+++ b/pictures/models.py
@@ -16,6 +16,7 @@ from PIL import Image, ImageOps
 
 __all__ = ["PictureField", "PictureFieldFile"]
 
+from django.utils.module_loading import import_string
 
 from pictures import conf, utils
 
@@ -98,9 +99,7 @@ class PictureFieldFile(ImageFieldFile):
 
     def save_all(self):
         if self:
-            from . import tasks
-
-            tasks.process_picture(self)
+            import_string(conf.get_settings().PROCESSOR)(self)
 
     def delete(self, save=True):
         self.delete_all()


### PR DESCRIPTION
To simplify customizations the image processort can be swapped.
Previously, it was necessary to override the PictureFieldFile.
Now, all that needs to be done is setting a custom value for
the `PICTURES["PROCESSOR"]` setting.
