### PR TITLE
Fix #144 -- Improve DRM serialization performance by filtering source and ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,9 +246,21 @@ class PictureSerializer(serializers.Serializer):
     picture = PictureField()
 ```
 
-You may provide optional GET parameters to the serializer, to specify the aspect
-ratio and breakpoints you want to include in the response. The parameters are
-prefixed with the `fieldname_` to avoid conflicts with other fields.
+The response can be restricted to a single aspect ratio and image source, by
+providing the `aspect_ratio` and `image_source` arguments to the field.
+
+```python
+from rest_framework import serializers
+from pictures.contrib.rest_framework import PictureField
+
+class PictureSerializer(serializers.Serializer):
+    picture = PictureField(aspect_ratio="16/9", image_source="WEBP")
+```
+
+You also may provide optional GET parameters to the serializer,
+to specify the aspect ratio and breakpoints you want to include in the response.
+The parameters are prefixed with the `fieldname_`
+to avoid conflicts with other fields.
 
 ```bash
 curl http://localhost:8000/api/path/?picture_ratio=16%2F9&picture_m=6&picture_l=4


### PR DESCRIPTION
This is an early draft of a possible direction.
I did not go all fancy and did not add tests before I validate this with you.

The manual test on 5000 objects showed me this:

```
DRF ImageField serialization TIME:  0.15182900428771973
PictureField serialization TIME:  12.384335041046143
PictureField serialization IMPROVED TIME:  3.4643609523773193
```