### PR TITLE
Fix caching issue on empty dimention fields

### DIFF
--- a/pictures/models.py
+++ b/pictures/models.py
@@ -121,25 +121,19 @@ class PictureFieldFile(ImageFieldFile):
     @property
     def width(self):
         self._require_file()
-        if (
-            self._committed
-            and self.field.width_field
-            and hasattr(self.instance, self.field.width_field)
-        ):
-            # get width from width field, to avoid loading image
-            return getattr(self.instance, self.field.width_field)
+        if self._committed and self.field.width_field:
+            if width := getattr(self.instance, self.field.width_field, None):
+                # get width from width field, to avoid loading image
+                return width
         return self._get_image_dimensions()[0]
 
     @property
     def height(self):
         self._require_file()
-        if (
-            self._committed
-            and self.field.height_field
-            and hasattr(self.instance, self.field.height_field)
-        ):
-            # get height from height field, to avoid loading image
-            return getattr(self.instance, self.field.height_field)
+        if self._committed and self.field.height_field:
+            if height := getattr(self.instance, self.field.height_field, None):
+                # get height from height field, to avoid loading image
+                return height
         return self._get_image_dimensions()[1]
 
     @property

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -186,6 +186,22 @@ class TestPictureFieldFile:
             assert obj.picture.aspect_ratios["1/1"]["WEBP"][100].path.exists()
             assert not path.exists()
 
+    @pytest.mark.django_db
+    def test_width(self, stub_worker, image_upload_file):
+        obj = SimpleModel(picture=image_upload_file)
+        obj.save()
+        obj.picture_width = None
+
+        assert obj.picture.width == 800
+
+    @pytest.mark.django_db
+    def test_height(self, stub_worker, image_upload_file):
+        obj = SimpleModel(picture=image_upload_file)
+        obj.save()
+        obj.picture_height = None
+
+        assert obj.picture.height == 800
+
 
 class TestPictureField:
     @pytest.mark.django_db


### PR DESCRIPTION
The width and height fields may be empty, like in cases where you
newly add the fields. In those cases, they width and hight properties
shall not return the false null values but read the dimentions form file.
