### PR TITLE
use breakpoints and grid_columns field settings over global settings

### DIFF
--- a/pictures/templatetags/pictures.py
+++ b/pictures/templatetags/pictures.py
@@ -29,7 +29,7 @@ def picture(field_file, img_alt=None, ratio=None, container=None, **kwargs):
             f"Invalid ratio: {ratio}. Choices are: {', '.join(filter(None, field_file.aspect_ratios.keys()))}"
         ) from e
     for key, value in kwargs.items():
-        if key in settings.BREAKPOINTS:
+        if key in field_file.field.breakpoints:
             breakpoints[key] = value
         elif key.startswith("picture_"):
             picture_attrs[key[8:]] = value
@@ -43,7 +43,12 @@ def picture(field_file, img_alt=None, ratio=None, container=None, **kwargs):
             "alt": img_alt,
             "ratio": (ratio or "3/2").replace("/", "x"),
             "sources": sources,
-            "media": utils.sizes(container_width=container, **breakpoints),
+            "media": utils.sizes(
+                cols=field_file.field.grid_columns,
+                container_width=container,
+                breakpoint_settings=field_file.field.breakpoints,
+                **breakpoints,
+            ),
             "picture_attrs": picture_attrs,
             "img_attrs": img_attrs,
             "use_placeholders": settings.USE_PLACEHOLDERS,


### PR DESCRIPTION
Hello :) 

While playing with your great package I stumbled upon what I believe is a bug. I fixed some of it in this PR (at least it behaves better locally) but I am pretty sure there could be more I haven't fixed.

The basic issue is not using the `breakpoints` and `grid_columns` settings from `PictureField` in the `{% picture %}` templatetag and related utilities. Instead the global settings are always used. If I understand the intention of the code correctly that is not supposed to happen.

I still import settings  to make the unit tests work, I am sure you have a better way of doing that, feel free to edit. 

Let me know if you have questions :+1: 