### PR TITLE
Update Python & Django version support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,12 +75,12 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.12"
+          - "3.13"
         django-version:
-          - "3.2"  # LTS
+          - "4.2"  # LTS
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -103,11 +103,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.11"
+          - "3.12"
         django-version:
           # LTS gets tested on all OS
-          - "4.1"
-          - "4.2"
+          - "5.1"
+          - "5.2"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/pictures/models.py
+++ b/pictures/models.py
@@ -104,7 +104,7 @@ class PillowPicture(Picture):
     def path(self) -> Path:
         return Path(self.storage.path(self.name))
 
-    def process(self, image) -> "Image":
+    def process(self, image) -> Image:
         image = ImageOps.exif_transpose(image)  # crates a copy
         height = self.height or self.width / Fraction(*image.size)
         size = math.floor(self.width), math.floor(height)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,18 +23,18 @@ classifiers = [
   "Topic :: Software Development",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Framework :: Django",
-  "Framework :: Django :: 3.2",
-  "Framework :: Django :: 4.1",
   "Framework :: Django :: 4.2",
+  "Framework :: Django :: 5.1",
+  "Framework :: Django :: 5.2",
 ]
-requires-python = ">=3.8"
-dependencies = ["django>=3.2.0", "pillow>=9.0.0"]
+requires-python = ">=3.9"
+dependencies = ["django>=4.2.0", "pillow>=9.0.0"]
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
* Drop Python 3.8 (EOL)
* Drop Django 3.2 LTS (EOL)
* Drop Django 4.1 (EOL)
* Add Django 5.1
* Add Django 5.2 LTS