### PR TITLE
Resolve #160 -- Add `picture_processed` signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ from pictures.signals import picture_processed
 class Profile(models.Model):
     title = models.CharField(max_length=255)
     picture = PictureField(upload_to="avatars")
-    picture_processed = models.BooleanField(editable=False, null=True)
+    picture_processed = models.BooleanField(editable=False, default=False)
 
 
 

--- a/README.md
+++ b/README.md
@@ -229,14 +229,15 @@ processor, should you need to do some custom processing.
 
 ### Signals
 
-The async image processing emits a signal when the task is complete.
-You can use that to store when the pictures have been processed,
-so that a placeholder could be rendered in the meantime.
+Image processing emits a `picture_processed` signal after successfull completion.
+The signal can be used to persissed the processing state or to trigger other events.
 
 ```python
 # models.py
 from django.db import models
+from django.dispatch import receiver
 from pictures.models import PictureField
+from pictures.signals import picture_processed
 
 
 class Profile(models.Model):
@@ -245,15 +246,11 @@ class Profile(models.Model):
     picture_processed = models.BooleanField(editable=False, null=True)
 
 
-# signals.py
-from django.dispatch import receiver
-from pictures import signals
-
-from .models import Profile
 
 
-@receiver(signals.picture_processed, sender=Profile._meta.get_field("picture"))
-def picture_processed_handler(*, sender, file_name, **__):
+
+@receiver(picture_processed, sender=Profile._meta.get_field("picture"))
+def picture_processed_handler(sender, file_name, **kwargs):
     sender.model.objects.filter(**{sender.name: file_name}).update(
         picture_processed=True
     )

--- a/pictures/models.py
+++ b/pictures/models.py
@@ -179,8 +179,8 @@ class PictureFieldFile(ImageFieldFile):
     @property
     def sender(self):
         return (
-            self.instance._meta.app_label,
-            self.instance._meta.model_name,
+            self.field.model._meta.app_label,
+            self.field.model._meta.model_name,
             self.field.name,
         )
 

--- a/pictures/models.py
+++ b/pictures/models.py
@@ -155,9 +155,9 @@ class PictureFieldFile(ImageFieldFile):
             import_string(conf.get_settings().PROCESSOR)(
                 self.storage.deconstruct(),
                 self.name,
+                self.sender,
                 [],
                 [i.deconstruct() for i in self.get_picture_files_list()],
-                self.instance_name,
             )
 
     def update_all(self, other: PictureFieldFile | None = None):
@@ -170,14 +170,18 @@ class PictureFieldFile(ImageFieldFile):
             import_string(conf.get_settings().PROCESSOR)(
                 self.storage.deconstruct(),
                 self.name,
+                self.sender,
                 [i.deconstruct() for i in new],
                 [i.deconstruct() for i in old],
-                self.instance_name,
             )
 
     @property
-    def instance_name(self):
-        return f"{self.instance._meta.app_label}.{self.instance._meta.model_name}.{self.field.name}"
+    def sender(self):
+        return (
+            self.instance._meta.app_label,
+            self.instance._meta.model_name,
+            self.field.name,
+        )
 
     @property
     def width(self):

--- a/pictures/models.py
+++ b/pictures/models.py
@@ -157,6 +157,7 @@ class PictureFieldFile(ImageFieldFile):
                 self.name,
                 [],
                 [i.deconstruct() for i in self.get_picture_files_list()],
+                self.instance_name,
             )
 
     def update_all(self, other: PictureFieldFile | None = None):
@@ -171,7 +172,12 @@ class PictureFieldFile(ImageFieldFile):
                 self.name,
                 [i.deconstruct() for i in new],
                 [i.deconstruct() for i in old],
+                self.instance_name,
             )
+
+    @property
+    def instance_name(self):
+        return f"{self.instance._meta.app_label}.{self.instance._meta.model_name}.{self.field.name}"
 
     @property
     def width(self):

--- a/pictures/signals.py
+++ b/pictures/signals.py
@@ -1,3 +1,3 @@
 import django.dispatch
 
-process_picture_done = django.dispatch.Signal()
+picture_processed = django.dispatch.Signal()

--- a/pictures/signals.py
+++ b/pictures/signals.py
@@ -1,0 +1,3 @@
+import django.dispatch
+
+process_picture_done = django.dispatch.Signal()

--- a/pictures/tasks.py
+++ b/pictures/tasks.py
@@ -5,7 +5,7 @@ from typing import Protocol
 from django.db import transaction
 from PIL import Image
 
-from pictures import conf, utils
+from pictures import conf, signals, utils
 
 
 def noop(*args, **kwargs) -> None:
@@ -40,6 +40,14 @@ def _process_picture(
     for picture in old:
         picture = utils.reconstruct(*picture)
         picture.delete()
+
+    signals.process_picture_done.send(
+        sender=_process_picture,
+        storage=storage.deconstruct(),
+        file_name=file_name,
+        new=new,
+        old=old,
+    )
 
 
 process_picture: PictureProcessor = _process_picture

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -4,6 +4,7 @@ import pytest
 from django.core.management import call_command
 from django.db import models
 from django.db.models.fields.files import ImageFieldFile
+from django.test.utils import isolate_apps
 
 from pictures import migrations
 from pictures.models import PictureField
@@ -117,6 +118,7 @@ class TestAlterPictureField:
         assert not migration.to_picture_field.called
 
     @pytest.mark.django_db
+    @isolate_apps
     def test_update_pictures(self, request, stub_worker, image_upload_file):
         class ToModel(models.Model):
             name = models.CharField(max_length=100)
@@ -172,6 +174,7 @@ class TestAlterPictureField:
         assert not luke.picture
 
     @pytest.mark.django_db
+    @isolate_apps
     def test_update_pictures__with_empty_pictures(
         self, request, stub_worker, image_upload_file
     ):

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,6 +1,8 @@
 from unittest.mock import Mock
 
 import pytest
+from django.apps import apps
+from django.dispatch import receiver
 
 from pictures import signals, tasks
 from tests.testapp.models import SimpleModel
@@ -26,4 +28,44 @@ def test_process_picture_sends_process_picture_done(image_upload_file):
         file_name=obj.picture.name,
         new=[i.deconstruct() for i in obj.picture.get_picture_files_list()],
         old=[],
+        field="",
     )
+
+
+@pytest.mark.django_db
+def test_process_picture_sends_process_picture_done_on_create(image_upload_file):
+    handler = Mock()
+    signals.process_picture_done.connect(handler)
+
+    obj = SimpleModel.objects.create(picture=image_upload_file)
+
+    handler.assert_called_once_with(
+        signal=signals.process_picture_done,
+        sender=SimpleModel,
+        storage=obj.picture.storage.deconstruct(),
+        file_name=obj.picture.name,
+        new=[i.deconstruct() for i in obj.picture.get_picture_files_list()],
+        old=[],
+        field="testapp.simplemodel.picture",
+    )
+
+
+@pytest.mark.django_db
+def test_processed_object_found(image_upload_file):
+    obj = SimpleModel.objects.create()
+
+    found_object = None
+
+    @receiver(signals.process_picture_done, sender=SimpleModel)
+    def handler(*, file_name, field, **__):
+        nonlocal found_object
+        app_label, model_name, field_name = field.split(".")
+        model = apps.get_model(app_label=app_label, model_name=model_name)
+
+        # Users can now modify the object that process_picture_done
+        # corresponds to
+        found_object = model.objects.get(**{field_name: file_name})
+
+    obj.picture.save("image.png", image_upload_file)
+
+    assert obj == found_object

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -4,10 +4,12 @@ import pytest
 from django.dispatch import receiver
 
 from pictures import signals, tasks
+from tests.test_migrations import skip_dramatiq
 from tests.testapp.models import SimpleModel
 
 
 @pytest.mark.django_db
+@skip_dramatiq
 def test_process_picture_sends_process_picture_done(image_upload_file):
     obj = SimpleModel.objects.create(picture=image_upload_file)
 
@@ -31,6 +33,7 @@ def test_process_picture_sends_process_picture_done(image_upload_file):
 
 
 @pytest.mark.django_db
+@skip_dramatiq
 def test_process_picture_sends_process_picture_done_on_create(image_upload_file):
     handler = Mock()
     signals.picture_processed.connect(handler)
@@ -47,6 +50,7 @@ def test_process_picture_sends_process_picture_done_on_create(image_upload_file)
 
 
 @pytest.mark.django_db
+@skip_dramatiq
 def test_processed_object_found(image_upload_file):
     obj = SimpleModel.objects.create()
 

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,7 +1,6 @@
 from unittest.mock import Mock
 
 import pytest
-from django.apps import apps
 from django.dispatch import receiver
 
 from pictures import signals, tasks
@@ -13,40 +12,37 @@ def test_process_picture_sends_process_picture_done(image_upload_file):
     obj = SimpleModel.objects.create(picture=image_upload_file)
 
     handler = Mock()
-    signals.process_picture_done.connect(handler)
+    signals.picture_processed.connect(handler)
 
     tasks._process_picture(
         obj.picture.storage.deconstruct(),
         obj.picture.name,
+        obj.picture.sender,
         new=[i.deconstruct() for i in obj.picture.get_picture_files_list()],
     )
 
     handler.assert_called_once_with(
-        signal=signals.process_picture_done,
-        sender=tasks._process_picture,
-        storage=obj.picture.storage.deconstruct(),
+        signal=signals.picture_processed,
+        sender=SimpleModel._meta.get_field("picture"),
         file_name=obj.picture.name,
         new=[i.deconstruct() for i in obj.picture.get_picture_files_list()],
         old=[],
-        field="",
     )
 
 
 @pytest.mark.django_db
 def test_process_picture_sends_process_picture_done_on_create(image_upload_file):
     handler = Mock()
-    signals.process_picture_done.connect(handler)
+    signals.picture_processed.connect(handler)
 
     obj = SimpleModel.objects.create(picture=image_upload_file)
 
     handler.assert_called_once_with(
-        signal=signals.process_picture_done,
-        sender=SimpleModel,
-        storage=obj.picture.storage.deconstruct(),
+        signal=signals.picture_processed,
+        sender=SimpleModel._meta.get_field("picture"),
         file_name=obj.picture.name,
         new=[i.deconstruct() for i in obj.picture.get_picture_files_list()],
         old=[],
-        field="testapp.simplemodel.picture",
     )
 
 
@@ -56,15 +52,12 @@ def test_processed_object_found(image_upload_file):
 
     found_object = None
 
-    @receiver(signals.process_picture_done, sender=SimpleModel)
-    def handler(*, file_name, field, **__):
+    @receiver(signals.picture_processed, sender=SimpleModel._meta.get_field("picture"))
+    def handler(*, sender, file_name, **__):
         nonlocal found_object
-        app_label, model_name, field_name = field.split(".")
-        model = apps.get_model(app_label=app_label, model_name=model_name)
 
-        # Users can now modify the object that process_picture_done
-        # corresponds to
-        found_object = model.objects.get(**{field_name: file_name})
+        # Users can now modify the object that picture_processed corresponds to
+        found_object = sender.model.objects.get(**{sender.name: file_name})
 
     obj.picture.save("image.png", image_upload_file)
 

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,29 @@
+from unittest.mock import Mock
+
+import pytest
+
+from pictures import signals, tasks
+from tests.testapp.models import SimpleModel
+
+
+@pytest.mark.django_db
+def test_process_picture_sends_process_picture_done(image_upload_file):
+    obj = SimpleModel.objects.create(picture=image_upload_file)
+
+    handler = Mock()
+    signals.process_picture_done.connect(handler)
+
+    tasks._process_picture(
+        obj.picture.storage.deconstruct(),
+        obj.picture.name,
+        new=[i.deconstruct() for i in obj.picture.get_picture_files_list()],
+    )
+
+    handler.assert_called_once_with(
+        signal=signals.process_picture_done,
+        sender=tasks._process_picture,
+        storage=obj.picture.storage.deconstruct(),
+        file_name=obj.picture.name,
+        new=[i.deconstruct() for i in obj.picture.get_picture_files_list()],
+        old=[],
+    )

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -18,6 +18,7 @@ def test_process_picture__file_cannot_be_reopened(image_upload_file):
     tasks._process_picture(
         obj.picture.storage.deconstruct(),
         obj.picture.name,
+        obj.picture.sender,
         new=[i.deconstruct() for i in obj.picture.get_picture_files_list()],
     )
 


### PR DESCRIPTION
This PR implements a new signal, `process_picture_done`, which is emitted when the task completes. It adds a new kwarg to `PictureProcessor` instances, `field`, which is a string so that it can be serialized in Celery and contains the model name, app label and field name. This, combined with the file name, allows the user to find which instance(s) this processing task corresponds to, so that they could then take action, e.g. by setting a processing done field in the database.

Any feedback welcome!

See https://github.com/codingjoe/django-pictures/discussions/160