### PR TITLE
Fix #284 --  Make image dimensions EXIF rotation aware

### DIFF
--- a/pictures/models.py
+++ b/pictures/models.py
@@ -10,6 +10,7 @@ from types import NotImplementedType
 
 from django.core import checks
 from django.core.files.base import ContentFile
+from django.core.files.images import get_image_dimensions
 from django.core.files.storage import Storage
 from django.db.models import ImageField
 from django.db.models.fields.files import ImageFieldFile
@@ -193,6 +194,25 @@ class PictureFieldFile(ImageFieldFile):
                 [i.deconstruct() for i in new],
                 [i.deconstruct() for i in old],
             )
+
+    def _get_image_dimensions(self):
+        if not hasattr(self, "_dimensions_cache"):
+            close = self.closed
+            self.open()
+            try:
+                self.seek(0)
+                width, height = get_image_dimensions(self)
+                self.seek(0)
+                # EXIF tag 0x0112 (Orientation); values 5-8 indicate the stored
+                # image is rotated 90 or 270 degrees, so width and height swap.
+                orientation = Image.open(self).getexif().get(0x0112, 1)
+                if orientation in (5, 6, 7, 8):
+                    width, height = height, width
+            finally:
+                if close:
+                    self.close()
+            self._dimensions_cache = (width, height)
+        return self._dimensions_cache
 
     @property
     def width(self):

--- a/pictures/models.py
+++ b/pictures/models.py
@@ -202,17 +202,16 @@ class PictureFieldFile(ImageFieldFile):
             try:
                 self.seek(0)
                 img = Image.open(self)
-                width, height = img.size
+                self._dimensions_cache = img.size
                 if img.getexif().get(0x0112, 1) in (5, 6, 7, 8):
                     # EXIF tag 0x0112 (Orientation); values 5-8 indicate the stored
                     # image is rotated 90 or 270 degrees, so width and height swap.
-                    width, height = height, width
+                    self._dimensions_cache = self._dimensions_cache[::-1]
             finally:
                 if close:
                     self.close()
                 else:
                     self.seek(file_pos)
-            self._dimensions_cache = (width, height)
         return self._dimensions_cache
 
     @property

--- a/pictures/models.py
+++ b/pictures/models.py
@@ -10,7 +10,6 @@ from types import NotImplementedType
 
 from django.core import checks
 from django.core.files.base import ContentFile
-from django.core.files.images import get_image_dimensions
 from django.core.files.storage import Storage
 from django.db.models import ImageField
 from django.db.models.fields.files import ImageFieldFile
@@ -197,20 +196,22 @@ class PictureFieldFile(ImageFieldFile):
 
     def _get_image_dimensions(self):
         if not hasattr(self, "_dimensions_cache"):
-            close = self.closed
-            self.open()
+            if close := self.closed:
+                self.open()
+            file_pos = self.tell()
             try:
                 self.seek(0)
-                width, height = get_image_dimensions(self)
-                self.seek(0)
-                # EXIF tag 0x0112 (Orientation); values 5-8 indicate the stored
-                # image is rotated 90 or 270 degrees, so width and height swap.
-                orientation = Image.open(self).getexif().get(0x0112, 1)
-                if orientation in (5, 6, 7, 8):
+                img = Image.open(self)
+                width, height = img.size
+                if img.getexif().get(0x0112, 1) in (5, 6, 7, 8):
+                    # EXIF tag 0x0112 (Orientation); values 5-8 indicate the stored
+                    # image is rotated 90 or 270 degrees, so width and height swap.
                     width, height = height, width
             finally:
                 if close:
                     self.close()
+                else:
+                    self.seek(file_pos)
             self._dimensions_cache = (width, height)
         return self._dimensions_cache
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ write_to = "pictures/_version.py"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--cov --tb=short -rxs  --benchmark-autosave --benchmark-group-by=fullname --benchmark-min-rounds=10"
+addopts = "--cov --tb=short -rxs  --benchmark-autosave --benchmark-min-rounds=10"
 testpaths = ["tests"]
 DJANGO_SETTINGS_MODULE = "tests.testapp.settings"
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -403,7 +403,7 @@ class TestAlterPictureField:
         call_command("migrate", "testapp", "0002")
 
     @pytest.mark.django_db
-    @pytest.mark.benchmark
+    @pytest.mark.benchmark(group="AlterPictureField.forward")
     def test_forward__performance(self, request, benchmark, large_image_upload_file):
         """Benchmark update_pictures migration operation across multiple objects."""
         pytest.importorskip("django", minversion="6.0")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock
 import pytest
 from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db.models.fields.files import ImageFieldFile
 from PIL import Image, ImageCms, ImageDraw
 
 from pictures.models import PictureField, PillowPicture
@@ -819,6 +820,109 @@ class TestPictureFieldFile:
     def test_delete_all__empty(self):
         obj = SimpleModel()
         obj.picture.delete_all()
+
+    @pytest.mark.django_db
+    def test__get_image_dimensions__closed_file_stays_closed(self, image_upload_file):
+        """Leave a closed file closed after reading dimensions."""
+        obj = SimpleModel.objects.create(picture=image_upload_file)
+        with contextlib.suppress(AttributeError):
+            del obj.picture._dimensions_cache
+        assert obj.picture.closed
+        obj.picture._get_image_dimensions()
+        assert obj.picture.closed
+
+    @pytest.mark.django_db
+    def test__get_image_dimensions__open_file_stays_open(self, image_upload_file):
+        """Leave an open file open after reading dimensions."""
+        obj = SimpleModel.objects.create(picture=image_upload_file)
+        with contextlib.suppress(AttributeError):
+            del obj.picture._dimensions_cache
+        obj.picture.open()
+        try:
+            obj.picture._get_image_dimensions()
+            assert not obj.picture.closed
+        finally:
+            obj.picture.close()
+
+    @pytest.mark.django_db
+    def test__get_image_dimensions__restores_cursor_position(self, image_upload_file):
+        """Restore the cursor position after reading dimensions from an open file."""
+        obj = SimpleModel.objects.create(picture=image_upload_file)
+        with contextlib.suppress(AttributeError):
+            del obj.picture._dimensions_cache
+        obj.picture.open()
+        try:
+            obj.picture.seek(42)
+            obj.picture._get_image_dimensions()
+            assert obj.picture.tell() == 42
+        finally:
+            obj.picture.close()
+
+    @pytest.mark.django_db
+    def test__get_image_dimensions__opens_and_closes_closed_file_once(
+        self, image_upload_file, monkeypatch
+    ):
+        """Open and close a closed file exactly once."""
+        obj = SimpleModel.objects.create(picture=image_upload_file)
+        with contextlib.suppress(AttributeError):
+            del obj.picture._dimensions_cache
+        open_spy = Mock(wraps=obj.picture.open)
+        close_spy = Mock(wraps=obj.picture.close)
+        monkeypatch.setattr(obj.picture, "open", open_spy)
+        monkeypatch.setattr(obj.picture, "close", close_spy)
+        obj.picture._get_image_dimensions()
+        open_spy.assert_called_once()
+        close_spy.assert_called_once()
+
+    @pytest.mark.django_db
+    def test__get_image_dimensions__does_not_open_or_close_open_file(
+        self, image_upload_file, monkeypatch
+    ):
+        """Skip open() and close() when the file is already open."""
+        obj = SimpleModel.objects.create(picture=image_upload_file)
+        with contextlib.suppress(AttributeError):
+            del obj.picture._dimensions_cache
+        obj.picture.open()
+        open_spy = Mock(wraps=obj.picture.open)
+        close_spy = Mock(wraps=obj.picture.close)
+        monkeypatch.setattr(obj.picture, "open", open_spy)
+        monkeypatch.setattr(obj.picture, "close", close_spy)
+        try:
+            obj.picture._get_image_dimensions()
+            open_spy.assert_not_called()
+            close_spy.assert_not_called()
+        finally:
+            obj.picture.close()
+
+    @pytest.mark.django_db
+    @pytest.mark.benchmark(group="pictures.models.SimpleModel._get_image_dimensions")
+    def test__get_image_dimensions__performance(
+        self, benchmark, large_image_upload_file
+    ):
+        """Benchmark image dimension reading including file open and close."""
+        obj = SimpleModel.objects.create(picture=large_image_upload_file)
+
+        def setup():
+            with contextlib.suppress(AttributeError):
+                del obj.picture._dimensions_cache
+
+        benchmark.pedantic(obj.picture._get_image_dimensions, setup=setup)
+
+    @pytest.mark.django_db
+    @pytest.mark.benchmark(group="pictures.models.SimpleModel._get_image_dimensions")
+    def test__get_image_dimensions__performance__org(
+        self, benchmark, large_image_upload_file
+    ):
+        """Benchmark image dimension reading including file open and close."""
+        obj = SimpleModel.objects.create(picture=large_image_upload_file)
+
+        def setup():
+            with contextlib.suppress(AttributeError):
+                del obj.picture._dimensions_cache
+
+        benchmark.pedantic(
+            lambda: ImageFieldFile._get_image_dimensions(obj.picture), setup=setup
+        )
 
 
 class TestPictureField:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -790,6 +790,26 @@ class TestPictureFieldFile:
         assert obj.picture.height == 800
 
     @pytest.mark.django_db
+    def test_width_height__exif_rotated(self, stub_worker, large_image_upload_file):
+        # fixture invariants: raw bytes are 2000x3000 with EXIF orientation 8.
+        large_image_upload_file.seek(0)
+        with Image.open(large_image_upload_file) as _img:
+            assert _img.size == (2000, 3000)
+            assert _img.getexif().get(0x0112) == 8
+        large_image_upload_file.seek(0)
+
+        obj = JPEGModel(picture=large_image_upload_file)
+        obj.save()
+        obj.picture_width = None
+        obj.picture_height = None
+        with contextlib.suppress(AttributeError):
+            del obj.picture._dimensions_cache
+
+        # orientation 8 swaps width and height.
+        assert obj.picture.width == 3000
+        assert obj.picture.height == 2000
+
+    @pytest.mark.django_db
     def test_update_all__empty(self, stub_worker, image_upload_file):
         obj = SimpleModel()
         obj.save()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -63,7 +63,7 @@ def test_django_tasks_misconfiguration__different_processor(settings):
 
 
 @pytest.mark.django_db
-@pytest.mark.benchmark
+@pytest.mark.benchmark(group="pictures.tasks._process_picture")
 def test_process_picture__performance(benchmark, large_image_upload_file):
     """Benchmark processing all picture sizes through the full pipeline."""
     pytest.importorskip("django", minversion="6.0")

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -15,9 +15,9 @@ picture_html = b"""
 picture_html_large = b"""
 <picture>
   <source type="image/avif"
-          srcset="/media/testapp/profile/image/800w.avif 800w, /media/testapp/profile/image/1600w.avif 1600w, /media/testapp/profile/image/100w.avif 100w, /media/testapp/profile/image/1400w.avif 1400w, /media/testapp/profile/image/900w.avif 900w, /media/testapp/profile/image/200w.avif 200w, /media/testapp/profile/image/1000w.avif 1000w, /media/testapp/profile/image/1800w.avif 1800w, /media/testapp/profile/image/300w.avif 300w, /media/testapp/profile/image/1100w.avif 1100w, /media/testapp/profile/image/400w.avif 400w, /media/testapp/profile/image/1200w.avif 1200w, /media/testapp/profile/image/2000w.avif 2000w, /media/testapp/profile/image/500w.avif 500w, /media/testapp/profile/image/600w.avif 600w, /media/testapp/profile/image/700w.avif 700w"
+          srcset="/media/testapp/profile/image/800w.avif 800w, /media/testapp/profile/image/1600w.avif 1600w, /media/testapp/profile/image/2400w.avif 2400w, /media/testapp/profile/image/100w.avif 100w, /media/testapp/profile/image/1400w.avif 1400w, /media/testapp/profile/image/900w.avif 900w, /media/testapp/profile/image/200w.avif 200w, /media/testapp/profile/image/1000w.avif 1000w, /media/testapp/profile/image/1800w.avif 1800w, /media/testapp/profile/image/300w.avif 300w, /media/testapp/profile/image/1100w.avif 1100w, /media/testapp/profile/image/400w.avif 400w, /media/testapp/profile/image/1200w.avif 1200w, /media/testapp/profile/image/2000w.avif 2000w, /media/testapp/profile/image/500w.avif 500w, /media/testapp/profile/image/600w.avif 600w, /media/testapp/profile/image/700w.avif 700w, /media/testapp/profile/image/2200w.avif 2200w"
           sizes="(min-width: 0px) and (max-width: 991px) 100vw, (min-width: 992px) and (max-width: 1199px) 33vw, 600px">
-  <img src="/media/testapp/profile/image.jpeg" alt="Spiderman" width="2000" height="3000">
+  <img src="/media/testapp/profile/image.jpeg" alt="Spiderman" width="3000" height="2000">
 </picture>
 """
 


### PR DESCRIPTION
Closes #284.

Browsers and `PIL.ImageOps.exif_transpose` rotate images based on their EXIF orientation tag, so the byte-level dimensions can differ from the displayed dimensions. Since source sets are already rotated on save, the width/height reported on `PictureFieldFile` must match the displayed image. Otherwise `width_field`/`height_field` cache the wrong orientation and the `<img>` tag emits swapped `width`/`height` attributes.

`PictureFieldFile._get_image_dimensions` now swaps the returned width/height when the EXIF orientation tag (0x0112) indicates a 90 or 270 degree rotation (values 5, 6, 7, 8). The dimensions are cached, matching Django's parent behavior.

The existing `test_picture__large` template snapshot was asserting the buggy pre-fix output; it is updated to reflect the correctly rotated dimensions. A new `test_width_height__exif_rotated` test pins the fix directly.